### PR TITLE
Improve usage of zenroom cryptocondition

### DIFF
--- a/cryptoconditions/fulfillment.py
+++ b/cryptoconditions/fulfillment.py
@@ -54,7 +54,6 @@ class Fulfillment(metaclass=ABCMeta):
         except (SubstrateUnderrunError, PyAsn1Error, TypeError) as exc:
             raise ASN1DecodeError('Failed to decode fulfillment.') from exc
         asn1_dict = nat_encode(asn1_obj)
-        print (f"asn1_dict : {asn1_dict}")
         return Fulfillment.from_asn1_dict(asn1_dict)
 
     @staticmethod

--- a/cryptoconditions/schemas/fulfillment.py
+++ b/cryptoconditions/schemas/fulfillment.py
@@ -98,7 +98,7 @@ ZenroomSha512Fulfillment.componentType = NamedTypes(
     NamedType(
         'keys',
         OctetString().subtype(
-            implicitTag=Tag(tagClassContext, tagFormatSimple, 1)),
+            implicitTag=Tag(tagClassContext, tagFormatSimple, 2)),
     ),
     # NamedType(
     #     'conf',

--- a/cryptoconditions/types/zenroom.py
+++ b/cryptoconditions/types/zenroom.py
@@ -78,14 +78,6 @@ class ZenroomSha256(BaseSha256):
             keys = json.loads(keys.decode())
         if not isinstance(keys, dict):
             raise TypeError('the keys must be a dictionary')
-        for name in keys.keys():
-            if not isinstance(name, str):
-                raise TypeError('{} is not the name of a user', name)
-            for k in keys[name].keys():
-                if not isinstance(k, str):
-                    raise TypeError('key type must be a string', name)
-                if not isinstance(keys[name][k], str):
-                    raise TypeError('the output of zencode keys must be a string', name)
         dict_keys = keys.keys()
         if 'asset' in dict_keys or 'metadata' in dict_keys:
             raise TypeError('keys cannot have a asset or a metadata key')

--- a/cryptoconditions/types/zenroom.py
+++ b/cryptoconditions/types/zenroom.py
@@ -86,6 +86,9 @@ class ZenroomSha256(BaseSha256):
                     raise TypeError('key type must be a string', name)
                 if not isinstance(keys[name][k], str):
                     raise TypeError('the output of zencode keys must be a string', name)
+        dict_keys = keys.keys()
+        if 'asset' in dict_keys or 'metadata' in dict_keys:
+            raise TypeError('keys cannot have a asset or a metadata key')
         return keys
 
     @property
@@ -101,6 +104,9 @@ class ZenroomSha256(BaseSha256):
         # Any dictionary (that can be serialized in json) could be valid data
         if not isinstance(data, dict):
             raise TypeError('the keys must be a dictionary')
+        dict_keys = data.keys()
+        if 'asset' in dict_keys or 'metadata' in dict_keys:
+            raise TypeError('keys cannot have a asset or a metadata key')
         # If data is not serializable this will throw an exception
         json.dumps(data)
         return data
@@ -176,11 +182,13 @@ class ZenroomSha256(BaseSha256):
     # the code would be different)
     def sign(self, message, condition_script, private_keys):
         message = json.loads(message)
-        data = {}
-        if 'data' in message['asset'].keys():
+        data = self.data if self.data is not None else {}
+        try:
             data['asset'] = message['asset']['data']
-        if self.data is not None:
-            data['output'] = self.data
+        except KeyError:
+            # If the message doesn't have a asset key
+            # go on without setting the asset in the data
+            pass
 
         result = zencode_exec(condition_script,
                               keys=json.dumps({"keyring": private_keys}),
@@ -273,28 +281,24 @@ class ZenroomSha256(BaseSha256):
             message = json.loads(message)
         except JSONDecodeError:
             return False
-        data = {}
+        data = {} if self._data is None else self._data
         try:
             if message['asset']['data']:
                 data['asset'] = message['asset']['data']
-        except JSONDecodeError:
+        except KeyError:
             pass
-        if self._data is not None:
-            data['output'] = self._data
 
         # There could also be some data in the metadata,
         # this is an output of the condition script which
         # become an input for the fulfillment script
         try:
-            if message['metadata'] and message['metadata']['data']:
-                data['result'] = message['metadata']['data']
-        except ValueError:
+            if message['metadata']['data']:
+                data['metadata'] = message['metadata']['data']
+        except KeyError:
             pass
         # We can put pulic keys either in the keys or the data of zenroom
-        data.update(self.keys)
-
         result = zencode_exec(self.script,
-                              keys="{}",
+                              keys=json.dumps(self._keys),
                               data=json.dumps(data))
         try:
             message['metadata']['result']
@@ -303,10 +307,6 @@ class ZenroomSha256(BaseSha256):
 
         try:
             result = json.loads(result.output)
-            # "Then print the string 'ok'" in zenroom produces a
-            # dictionary of array with the string 'ok'
-            # this is stored in result and compared against the content of
-            # the metadata
             return result == message['metadata']['result']
         except JSONDecodeError:
             return False

--- a/tests/test_zenroom.py
+++ b/tests/test_zenroom.py
@@ -263,3 +263,58 @@ def test_use_asset_and_metadata():
     message = json.dumps(message)
     assert(zenSha.validate(message=message))
 
+def test_valid_keys():
+    zenSha = ZenroomSha256(
+            script="Given I am 'Alice'\nGiven I have my 'keyring'\nThen print the string 'ok'",
+            keys={
+                "Alice": {
+                    "keyring": {
+                        "bitcoin": "L1r9SjgSsaZUaiKb38mSYoZWGENg2J52kgCJyGAmPJNjrPzkcXWc",
+                        "ecdh": "aODoXr8wCpFiVRc0RqWopKtS2wD73fqC1LyXJxePfnQ=",
+                        "ethereum": "78ff5aaeabfa1b800ccab5c60dbaf1e249be5d2707993f4fbd27df09bca7e821",
+                        "reflow": "BxsBo94hLKU96c0MX4GehsrQUfIGY7UgMqdZaWaHwrE=",
+                        "schnorr": "aPC2VllaEbQJlQvo8KVKQGf8oMMGERb099sCbswpPq0="
+                        }
+                    }
+                }
+            )
+
+    metadata = {
+            "result": {
+                "output": ["ok"]
+                },
+            }
+    asset = {
+            }
+    message = {
+            "metadata": metadata,
+            "asset": asset
+            }
+    message = json.dumps(message)
+    assert(zenSha.validate(message=message))
+    zenSha = ZenroomSha256(
+            script="Given I have the 'keyring'\nThen print the string 'ok'",
+            keys={
+                "keyring": {
+                    "bitcoin": "L1r9SjgSsaZUaiKb38mSYoZWGENg2J52kgCJyGAmPJNjrPzkcXWc",
+                    "ecdh": "aODoXr8wCpFiVRc0RqWopKtS2wD73fqC1LyXJxePfnQ=",
+                    "ethereum": "78ff5aaeabfa1b800ccab5c60dbaf1e249be5d2707993f4fbd27df09bca7e821",
+                    "reflow": "BxsBo94hLKU96c0MX4GehsrQUfIGY7UgMqdZaWaHwrE=",
+                    "schnorr": "aPC2VllaEbQJlQvo8KVKQGf8oMMGERb099sCbswpPq0="
+                    }
+                }
+            )
+
+    metadata = {
+            "result": {
+                "output": ["ok"]
+                },
+            }
+    asset = {
+            }
+    message = {
+            "metadata": metadata,
+            "asset": asset
+            }
+    message = json.dumps(message)
+    assert(zenSha.validate(message=message))

--- a/tests/test_zenroom.py
+++ b/tests/test_zenroom.py
@@ -14,6 +14,7 @@ import hashlib
 from cryptoconditions import ZenroomSha256, Fulfillment
 from zenroom import zencode_exec
 from json.decoder import JSONDecodeError
+import pytest
 
 # from zenroom import zencode_exec
 
@@ -111,7 +112,7 @@ def test_zenroom():
     Scenario 'ecdh': Bob verifies the signature from Alice
     Given I have a 'ecdh public key' from 'Alice'
     Given that I have a 'string dictionary' named 'houses' inside 'asset'
-    Given I have a 'signature' named 'signature' inside 'result'
+    Given I have a 'signature' named 'signature' inside 'metadata'
     When I verify the 'houses' has a signature in 'signature' by 'Alice'
     Then print the string 'ok'
     """
@@ -195,3 +196,70 @@ def test_zenroom():
     assert ff_from_uri_.script == zenSha.script
     assert ff_from_uri_.data == zenSha.data
     assert ff_from_uri_.keys == zenSha.keys
+
+
+def test_wrong_data():
+    with pytest.raises(TypeError):
+        ZenroomSha256(
+                script="Given nothing",
+                data={"asset": {}},
+        )
+    with pytest.raises(TypeError):
+        ZenroomSha256(
+                script="Given nothing",
+                keys={"metadata": {}},
+        )
+    ZenroomSha256(
+            script="Given nothing",
+            keys={},
+            data={},
+    )
+
+def test_no_asset_no_metadata():
+    zenSha = ZenroomSha256(
+            script="Given nothing\nThen print the string 'Hello'",
+    )
+    metadata = {
+        "result": {
+            "output": ["Hello"]
+        }
+    }
+    message = {
+        "metadata": metadata,
+    }
+    message = json.dumps(message)
+    assert(zenSha.validate(message=message))
+
+def test_use_asset_and_metadata():
+    script = """Given I have a 'string dictionary' named 'asset'
+        Given I have a 'string dictionary' named 'metadata'
+        Given I have a 'string' named 'word1' in 'asset'
+        Given I have a 'string' named 'word2' in 'metadata'
+        Given I have a 'string' named 'word3'
+        When I append 'word2' to 'word1'
+        When I append 'word3' to 'word1'
+        Then print the 'word1'"""
+    zenSha = ZenroomSha256(
+            script=script,
+            data={"word3":"3"}
+    )
+    metadata = {
+        "result": {
+            "word1": "123"
+        },
+        "data": {
+            "word2": "2"
+        }
+    }
+    asset = {
+        "data": {
+            "word1": "1"
+        }
+    }
+    message = {
+        "metadata": metadata,
+        "asset": asset
+    }
+    message = json.dumps(message)
+    assert(zenSha.validate(message=message))
+


### PR DESCRIPTION
- zenroom sees the data passed to ZenroomSha256 as is (not inside the output field)
- neither data nor keys can contain a asset or metadata key (it is populated from the real asset/metadata)
- zenroom sees the content of metadata with the key `metadata`