### PR TITLE
32 simplify zenroom usage within cryptoconditions

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,34 @@
+
+name: Deploy packages
+on: 
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: pip install -e .[dev] wheel
+
+      - name: Test build
+        run: python setup.py sdist bdist_wheel && twine check dist/*
+
+      - name: Upload to TestPyPI
+        run: |
+          python setup.py sdist bdist_wheel
+          python -m twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          #TWINE_REPOSITORY: testpypi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,10 @@
 Changelog
 =========
 
-0.10.0 (2022-09-05)
+0.10.0 (2022-09-08)
 ------------------
 
-* Integrated zenroom calling convention as defined in PRP 13
+* Integrated zenroom calling convention as defined in PRP 13 (breaking changes)
 * bumped base58 versions
 * improved linting
 * added audit

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+0.10.0 (2022-09-05)
+------------------
+
+* Integrated zenroom calling convention as defined in PRP 13
+* bumped base58 versions
+* improved linting
+* added audit
+
+
 0.9.11 (2022-06-27)
 ------------------
 

--- a/cryptoconditions/types/zenroom.py
+++ b/cryptoconditions/types/zenroom.py
@@ -290,7 +290,7 @@ class ZenroomSha256(BaseSha256):
         except ValueError:
             raise MalformedMessageException()
         except KeyError:
-            pass
+            pass #raise MalformedMessageException()
         data = {} if self._data is None else self._data
         data = message
 

--- a/cryptoconditions/types/zenroom.py
+++ b/cryptoconditions/types/zenroom.py
@@ -168,15 +168,9 @@ class ZenroomSha256(BaseSha256):
             message["output"]
         except KeyError:
             message["output"] = {}
-        try:
-            signature = {"signature": message["signature"]}
-        except KeyError:
-            signature = None
 
         input_data = {} if self._data is None else self._data
         input_data = {**input_data, **message["input"]}
-        if signature:
-            input_data = {**input_data, **signature}
         output_data = message["output"]
         return input_data, output_data
 
@@ -219,14 +213,10 @@ class ZenroomSha256(BaseSha256):
             data=json.dumps(in_data),
         )
 
-        logs = {"logs": result.logs}
-        raw_sig = result.output
-        if len(raw_sig) == 0:
-            raw_sig = '{}'
-        raw_sig = json.loads(raw_sig)
-        signature = {**raw_sig, **logs}
-        message = {**message, **signature}
-
+        output = result.output if len(result.output) > 0 else "{}"
+        output = json.loads(output)
+        response  = { "output": { **output, "logs": result.logs} }
+        message = { **message, **response }
         return json.dumps(message)
 
     # TODO Adapt according to outcomes of
@@ -243,8 +233,7 @@ class ZenroomSha256(BaseSha256):
             "script": base64_remove_padding(urlsafe_b64encode(self._script)),
             "data": base64_remove_padding(urlsafe_b64encode(self._data)),
             "keys": base64_remove_padding(urlsafe_b64encode(self._keys)),
-            # 'conf': base64_remove_padding(
-            #     urlsafe_b64encode(self.conf)),
+
         }
 
     # TODO Adapt according to outcomes of

--- a/cryptoconditions/types/zenroom.py
+++ b/cryptoconditions/types/zenroom.py
@@ -220,7 +220,10 @@ class ZenroomSha256(BaseSha256):
         )
 
         logs = {"logs": result.logs}
-        raw_sig = json.loads(result.output)
+        raw_sig = result.output
+        if len(raw_sig) == 0:
+            raw_sig = '{}'
+        raw_sig = json.loads(raw_sig)
         signature = {**raw_sig, **logs}
         message = {**message, **signature}
 

--- a/cryptoconditions/types/zenroom.py
+++ b/cryptoconditions/types/zenroom.py
@@ -20,11 +20,11 @@ from cryptoconditions.schemas.fingerprint import ZenroomFingerprintContents
 class ZenroomException(Exception):
     pass
 
+
 class MalformedMessageException(Exception):
     def __init__(self, *args, **kwargs):
-        return super().__init__(
-            "The message has to include the" \
-            " result of the zenroom execution",*args, **kwargs)
+        return super().__init__("The message has to include the" " result of the zenroom execution", *args, **kwargs)
+
 
 class ZenroomSha256(BaseSha256):
 
@@ -168,18 +168,16 @@ class ZenroomSha256(BaseSha256):
             message["output"]
         except KeyError:
             message["output"] = {}
-        try: 
-            signature = {"signature" : message["signature" ] }
+        try:
+            signature = {"signature": message["signature"]}
         except KeyError:
             signature = None
-            
 
-        
         input_data = {} if self._data is None else self._data
-        input_data = {**input_data,  **message["input"] }
+        input_data = {**input_data, **message["input"]}
         if signature:
-            input_data = {**input_data,  **signature }
-        output_data = message["output"] 
+            input_data = {**input_data, **signature}
+        output_data = message["output"]
         return input_data, output_data
 
     # TODO Adapt according to outcomes of
@@ -213,17 +211,17 @@ class ZenroomSha256(BaseSha256):
             message = json.loads(message)
         except JSONDecodeError:
             return False
-        
+
         in_data, out_data = self.convert_input_message_2_data(message)
         result = zencode_exec(
             condition_script,
             keys=json.dumps({"keyring": private_keys}),
             data=json.dumps(in_data),
         )
-        
+
         logs = {"logs": result.logs}
         raw_sig = json.loads(result.output)
-        signature = { **raw_sig, **logs }
+        signature = {**raw_sig, **logs}
         message = {**message, **signature}
 
         return json.dumps(message)
@@ -305,7 +303,7 @@ class ZenroomSha256(BaseSha256):
             return False
         except ValueError:
             raise MalformedMessageException()
-        
+
         in_data, out_data = self.convert_input_message_2_data(message)
 
         # We can put pulic keys either in the keys or the data of zenroom

--- a/cryptoconditions/types/zenroom.py
+++ b/cryptoconditions/types/zenroom.py
@@ -215,8 +215,8 @@ class ZenroomSha256(BaseSha256):
 
         output = result.output if len(result.output) > 0 else "{}"
         output = json.loads(output)
-        response  = { "output": { **output, "logs": result.logs} }
-        message = { **message, **response }
+        response = {"output": {**output, "logs": result.logs}}
+        message = {**message, **response}
         return json.dumps(message)
 
     # TODO Adapt according to outcomes of
@@ -233,7 +233,6 @@ class ZenroomSha256(BaseSha256):
             "script": base64_remove_padding(urlsafe_b64encode(self._script)),
             "data": base64_remove_padding(urlsafe_b64encode(self._data)),
             "keys": base64_remove_padding(urlsafe_b64encode(self._keys)),
-
         }
 
     # TODO Adapt according to outcomes of

--- a/cryptoconditions/version.py
+++ b/cryptoconditions/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.9.11"
-__short_version__ = "0.9"
+__version__ = "0.10.0"
+__short_version__ = "0.10"

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -33,13 +33,14 @@ ZENROOM-SHA-256
 
 The 'ZenroomSha256' Condition/Fulfillment is created by the following set of data: a script, keys and data.
 
-* the 'script' is that script that needs to be fulfilled.
+* the 'script' is that script that needs to be fulfilled/is exeuged
 
 * the keys are the keys that are used by the script
 
-* the data is some transaction based data
+* the data object is a JSON object with data that is used and addressed by the script
 
-The fulfillment can be signed-off by a script:
+
+The fulfillment (e.g. the script/policy/contract) can be signed-off by a script:
 
 * the message to be signed e.g. the transaction
 
@@ -54,8 +55,8 @@ Sample fulfillment:
     fulfill_script = """
     Scenario 'ecdh': Bob verifies the signature from Alice
     Given I have a 'ecdh public key' from 'Alice'
-    Given that I have a 'string dictionary' named 'houses' inside 'asset'
-    Given I have a 'signature' named 'signature' inside 'result'
+    Given that I have a 'string dictionary' named 'houses'
+    Given I have a 'signature' named 'signature'
     When I verify the 'houses' has a signature in 'signature' by 'Alice'
     Then print the string 'ok'
     """
@@ -67,37 +68,36 @@ Sample condition:
     condition_script = """
       Scenario 'ecdh': create the signature of an object
       Given I have the 'keyring'
-      Given that I have a 'string dictionary' named 'houses' inside 'asset'
+      Given that I have a 'string dictionary' named 'houses'
       When I create the signature of 'houses'
       Then print the 'signature'
       """
 
 The message being signed is required to be a JSON document and needs to contain the following set of data:
 
-* message.metadata containing a 'houses' object
+* message containing the input tag with the 'houses' object 
 
 .. code-block:: JSON
 
-    "data": {
-      "houses": [
-          {
-              "name": "Harry",
-              "team": "Gryffindor",
-          },
-          {
-              "name": "Draco",
-              "team": "Slytherin",
-          },
-      ],
+    "input": {
+        "houses": [
+            {
+                "name": "Harry",
+                "team": "Gryffindor",
+            },
+            {
+                "name": "Draco",
+                "team": "Slytherin",
+            },
+        ],
     }
 
-* message.metadata containing 
+* message output tag containing the output data (e.g. result of calling the sign-method)
 
 .. code-block:: JSON
 
-  "metadata" : {
-    "result": {"output": ["ok"]}
-  }
+    "output": {"output": ["ok"]}
+  
 
 ..
   ED25519-SHA-256

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ docs_require = [
 
 install_requires = [
     "zenroom==2.1.0.dev1655293214",
-    "base58==2.1.1",
+    "base58==2.1.0",
     "PyNaCl==1.4.0",
     "pyasn1==0.4.8",
     "cryptography==3.4.7",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ docs_require = [
 
 install_requires = [
     "zenroom==2.1.0.dev1655293214",
-    "base58==2.1.0",
+    "base58>=2.1.0",
     "PyNaCl==1.4.0",
     "pyasn1==0.4.8",
     "cryptography==3.4.7",

--- a/tests/test_zenroom.py
+++ b/tests/test_zenroom.py
@@ -31,7 +31,7 @@ GENERATE_KEYPAIR = """Rule input encoding base58
     Given that I am known as 'Pippo'
     When I create the ecdh key
     When I create the testnet key
-    Then print data"""
+    Then print keyring"""
 
 
 def genkey():
@@ -70,17 +70,20 @@ def test_zenroom():
     print(alice)
     print("============== BOB KEYPAIR =================")
     print(bob)
-    script = {
-        "houses": [
-            {
-                "name": "Harry",
-                "team": "Gryffindor",
-            },
-            {
-                "name": "Draco",
-                "team": "Slytherin",
-            },
-        ],
+    input_script = { 
+        "input"  : {
+            "houses": [
+                {
+                    "name": "Harry",
+                    "team": "Gryffindor",
+                },
+                {
+                    "name": "Draco",
+                    "team": "Slytherin",
+                },
+            ],
+        },
+        "output": ["ok"]
     }
     #    asset = {
     #        "data": {
@@ -108,7 +111,7 @@ def test_zenroom():
     #     `Then print the string 'ok'`,
     # results in
     #     { "output": ["ok"] }
-    metadata = {"result": {"output": ["ok"]}}
+    #metadata = {"result": {"output": ["ok"]}}
 
     fulfill_script = """
     Scenario 'ecdh': Bob verifies the signature from Alice
@@ -123,9 +126,7 @@ def test_zenroom():
 
     # CRYPTO-CONDITIONS: generate the condition uri
     condition_uri = zenSha.condition.serialize_uri()
-    # message = {"asset": asset, "metadata": metadata}
-    message = script
-    message = json.dumps(message)
+    input_script = json.dumps(input_script)
     print("====== GENERATE RESULT (METADATA) =======")
     condition_script = """
         Scenario 'ecdh': create the signature of an object
@@ -137,11 +138,12 @@ def test_zenroom():
 
     # THIS FILLS THE METADATA WITH THE RESULT
     try:
-        assert not zenSha.validate(message=message)
+        assert not zenSha.validate(message=input_script)
     except:
         pass
 
-    message = zenSha.sign(message, condition_script, alice)
+    message = zenSha.sign(input_script, condition_script, alice)
+    #message = json.dumps(message)
     assert zenSha.validate(message=message)
 
     # CRYPTO-CONDITIONS: generate the fulfillment uri
@@ -179,24 +181,11 @@ def test_wrong_data():
 
 # @pytest.mark.skip # the zenroom script ist not executed
 def test_no_asset_no_metadata():
-    script = """"Given nothing
-        Then print the string 'Hello'"""
+    script = "Given nothing\nThen print the string 'Hello'"
     zenSha = ZenroomSha256(script=script)
-    #message = {"output":["Hello"]}
-    message = {}
+    message = { "input": {}, "output":["Hello"]}
     message = json.dumps(message)
     assert zenSha.validate(message=message)
-
-def test_no_asset_no_metadata2():
-    script = """"Given I have a 'string' named 'test'
-        Then print the string 'Hello'"""
-    zenSha = ZenroomSha256(script=script)
-    #message = {"output":["Hello"]}
-    message = { "test": "testvalue"}
-    message = json.dumps(message)
-    assert zenSha.validate(message=message)
-
-
 
 def test_use_asset_and_metadata():
     script = """Given I have a 'string' named 'word1'
@@ -208,7 +197,7 @@ def test_use_asset_and_metadata():
     zenSha = ZenroomSha256(script=script)  # , data={"word3": "3"})
     #    metadata = {"output": {")#word1": "123"}, "data": {"word2": "2"}}
     #    asset = {"data": {"word1": "1"}}
-    message = {"word3": "3", "word1": "1", "word2": "2", "output": {"word1": "123"}}
+    message = {"input" : {"word3": "3", "word1": "1", "word2": "2" }, "output": {"word1": "123"}}
     message = json.dumps(message)
     assert zenSha.validate(message=message)
 

--- a/tests/test_zenroom.py
+++ b/tests/test_zenroom.py
@@ -179,12 +179,23 @@ def test_wrong_data():
 
 # @pytest.mark.skip # the zenroom script ist not executed
 def test_no_asset_no_metadata():
-    script = """Given nothing
-    Then print the string 'Hello'"""
+    script = """"Given nothing
+        Then print the string 'Hello'"""
     zenSha = ZenroomSha256(script=script)
-    message = {"output": ["Hello"]}
+    #message = {"output":["Hello"]}
+    message = {}
     message = json.dumps(message)
     assert zenSha.validate(message=message)
+
+def test_no_asset_no_metadata2():
+    script = """"Given I have a 'string' named 'test'
+        Then print the string 'Hello'"""
+    zenSha = ZenroomSha256(script=script)
+    #message = {"output":["Hello"]}
+    message = { "test": "testvalue"}
+    message = json.dumps(message)
+    assert zenSha.validate(message=message)
+
 
 
 def test_use_asset_and_metadata():

--- a/tests/test_zenroom.py
+++ b/tests/test_zenroom.py
@@ -70,8 +70,13 @@ def test_zenroom():
     print(alice)
     print("============== BOB KEYPAIR =================")
     print(bob)
-    input_script = { 
-        "input"  : {
+
+    # the result key is the expected result of the fulfill script
+    # it depends on the script, in this case I know that
+    #     `Then print the string 'ok'`,
+
+    input_script = {
+        "input": {
             "houses": [
                 {
                     "name": "Harry",
@@ -83,35 +88,15 @@ def test_zenroom():
                 },
             ],
         },
-        "output": ["ok"]
+        "output": ["ok"],
     }
-    #    asset = {
-    #        "data": {
-    #            "houses": [
-    #                {
-    #                    "name": "Harry",
-    #                    "team": "Gryffindor",
-    #                },
-    #                {
-    #                    "name": "Draco",
-    #                    "team": "Slytherin",
-    #                },
-    #            ],
-    #        }
-    #    }
+
     zen_public_keys = sk2pk("Alice", alice)
     zen_public_keys.update(sk2pk("Bob", bob))
 
     data = {"also": "more data"}
     print("============== PUBLIC IDENTITIES =================")
     print(zen_public_keys)
-
-    # the result key is the expected result of the fulfill script
-    # it depends on the script, in this case I know that
-    #     `Then print the string 'ok'`,
-    # results in
-    #     { "output": ["ok"] }
-    #metadata = {"result": {"output": ["ok"]}}
 
     fulfill_script = """
     Scenario 'ecdh': Bob verifies the signature from Alice
@@ -143,7 +128,7 @@ def test_zenroom():
         pass
 
     message = zenSha.sign(input_script, condition_script, alice)
-    #message = json.dumps(message)
+    # don't dump message like json.dumps(message) - beause this has already been performed by the sign-call
     assert zenSha.validate(message=message)
 
     # CRYPTO-CONDITIONS: generate the fulfillment uri
@@ -179,13 +164,13 @@ def test_wrong_data():
     )
 
 
-# @pytest.mark.skip # the zenroom script ist not executed
 def test_no_asset_no_metadata():
     script = "Given nothing\nThen print the string 'Hello'"
     zenSha = ZenroomSha256(script=script)
-    message = { "input": {}, "output":["Hello"]}
+    message = {"input": {}, "output": ["Hello"]}
     message = json.dumps(message)
     assert zenSha.validate(message=message)
+
 
 def test_use_asset_and_metadata():
     script = """Given I have a 'string' named 'word1'
@@ -194,10 +179,8 @@ def test_use_asset_and_metadata():
         When I append 'word2' to 'word1'
         When I append 'word3' to 'word1'
         Then print the 'word1'"""
-    zenSha = ZenroomSha256(script=script)  # , data={"word3": "3"})
-    #    metadata = {"output": {")#word1": "123"}, "data": {"word2": "2"}}
-    #    asset = {"data": {"word1": "1"}}
-    message = {"input" : {"word3": "3", "word1": "1", "word2": "2" }, "output": {"word1": "123"}}
+    zenSha = ZenroomSha256(script=script)
+    message = {"input": {"word3": "3", "word1": "1", "word2": "2"}, "output": {"word1": "123"}}
     message = json.dumps(message)
     assert zenSha.validate(message=message)
 

--- a/tests/test_zenroom.py
+++ b/tests/test_zenroom.py
@@ -73,7 +73,7 @@ fulfillscript = """
     Then print the string 'ok'
     """
 
-condictionalscript ="""
+condictionalscript = """
         Scenario 'ecdh': create the signature of an object
         Given I have the 'keyring'
         Given that I have a 'string dictionary' named 'houses'
@@ -81,7 +81,8 @@ condictionalscript ="""
         Then print the 'signature'
         """
 
-def test_valid_signature( ):
+
+def test_valid_signature():
     alice, bob = genkey(), genkey()
     # the result key is the expected result of the fulfill script
     # it depends on the script, in this case I know that
@@ -122,11 +123,11 @@ def test_valid_signature( ):
     message = zenSha.sign(script_input, condictionalscript, alice)
     # don't dump message like json.dumps(message) - beause this has already been performed by the sign-call
     output = json.loads(message)
-    output["input"]["signature"]= output["output"]["signature"] # verify input signature
+    output["input"]["signature"] = output["output"]["signature"]  # verify input signature
     del output["output"]["signature"]
     del output["output"]["logs"]
-    output["output"] =["ok"] # define expected output that is to be compared
-    input_msg =json.dumps(output)
+    output["output"] = ["ok"]  # define expected output that is to be compared
+    input_msg = json.dumps(output)
     assert zenSha.validate(message=input_msg)
 
     # CRYPTO-CONDITIONS: generate the fulfillment uri
@@ -144,15 +145,14 @@ def test_valid_signature( ):
     assert ff_from_uri_.keys == zenSha.keys
 
 
-def test_invalid_signing_call( ):
+def test_invalid_signing_call():
     alice, bob = genkey(), genkey()
     # the result key is the expected result of the fulfill script
     # it depends on the script, in this case I know that
     #     `Then print the string 'ok'`,
 
     script_input = {
-        "input": {
-        },
+        "input": {},
         "output": ["ok"],
     }
 

--- a/tests/test_zenroom.py
+++ b/tests/test_zenroom.py
@@ -75,7 +75,7 @@ def test_zenroom():
     # it depends on the script, in this case I know that
     #     `Then print the string 'ok'`,
 
-    input_script = {
+    script_input = {
         "input": {
             "houses": [
                 {
@@ -111,7 +111,7 @@ def test_zenroom():
 
     # CRYPTO-CONDITIONS: generate the condition uri
     condition_uri = zenSha.condition.serialize_uri()
-    input_script = json.dumps(input_script)
+    script_input = json.dumps(script_input)
     print("====== GENERATE RESULT (METADATA) =======")
     condition_script = """
         Scenario 'ecdh': create the signature of an object
@@ -123,11 +123,11 @@ def test_zenroom():
 
     # THIS FILLS THE METADATA WITH THE RESULT
     try:
-        assert not zenSha.validate(message=input_script)
+        assert not zenSha.validate(message=script_input)
     except:
         pass
 
-    message = zenSha.sign(input_script, condition_script, alice)
+    message = zenSha.sign(script_input, condition_script, alice)
     # don't dump message like json.dumps(message) - beause this has already been performed by the sign-call
     assert zenSha.validate(message=message)
 

--- a/tests/test_zenroom.py
+++ b/tests/test_zenroom.py
@@ -121,7 +121,13 @@ def test_valid_signature( ):
 
     message = zenSha.sign(script_input, condictionalscript, alice)
     # don't dump message like json.dumps(message) - beause this has already been performed by the sign-call
-    assert zenSha.validate(message=message)
+    output = json.loads(message)
+    output["input"]["signature"]= output["output"]["signature"] # verify input signature
+    del output["output"]["signature"]
+    del output["output"]["logs"]
+    output["output"] =["ok"] # define expected output that is to be compared
+    input_msg =json.dumps(output)
+    assert zenSha.validate(message=input_msg)
 
     # CRYPTO-CONDITIONS: generate the fulfillment uri
     fulfillment_uri = zenSha.serialize_uri()


### PR DESCRIPTION
Make sure the title of this pull request has the form:

The zenroom calling convention was implicitly defined by the integration.
Too many scenarios where possible and a well defined approach was missing structured the behavior in a clear way.

## Solution

A precise and clear way on how to call zenroom got proposed and defined in PRP 13.
This got integrated into the cryptoconditions.

## Issues Resolved

Resolves PRP #13 https://github.com/planetmint/PRPs/pull/23


## Checklist

- [X] version number increased
- [X] CHANGELOG.md updated
- [X] unit test added (adjusted)
- [X] documentation updated or added